### PR TITLE
fix: D1トランザクションエラーを修正

### DIFF
--- a/api/src/routes/interactions.ts
+++ b/api/src/routes/interactions.ts
@@ -182,38 +182,36 @@ interactionsRoute.post("/", async (c) => {
 
     const customId = interaction.data?.custom_id ?? "";
 
-    // 質問への回答（重複・誤ユーザー書き込みを防ぐためアトミックに処理）
+    // 質問への回答（answeredAt IS NULL の条件付き UPDATE で重複書き込みを防止）
     if (customId.startsWith("question_reply:")) {
       const questionId = customId.slice("question_reply:".length);
       c.executionCtx.waitUntil(
         (async () => {
           try {
-            await db.transaction(async (tx) => {
-              const updated = await tx
-                .update(questions)
-                .set({ answeredAt: new Date() })
-                .where(
-                  and(
-                    eq(questions.id, questionId),
-                    eq(questions.userId, user.id),
-                    isNull(questions.answeredAt)
-                  )
+            const updated = await db
+              .update(questions)
+              .set({ answeredAt: new Date() })
+              .where(
+                and(
+                  eq(questions.id, questionId),
+                  eq(questions.userId, user.id),
+                  isNull(questions.answeredAt)
                 )
-                .returning({ id: questions.id });
+              )
+              .returning({ id: questions.id });
 
-              if (updated.length === 0) {
-                // 既回答 or 別ユーザーの質問
-                console.warn("question_reply: スキップ（既回答または権限なし）", { questionId, userId: user.id });
-                return;
-              }
+            if (updated.length === 0) {
+              // 既回答 or 別ユーザーの質問
+              console.warn("question_reply: スキップ（既回答または権限なし）", { questionId, userId: user.id });
+              return;
+            }
 
-              await tx.insert(logs).values({
-                id: nanoid(),
-                userId: user.id,
-                questionId,
-                content,
-                source: "discord_reply"
-              });
+            await db.insert(logs).values({
+              id: nanoid(),
+              userId: user.id,
+              questionId,
+              content,
+              source: "discord_reply"
             });
           } catch (err) {
             console.error("question_reply: ログ保存エラー", err);


### PR DESCRIPTION
## 原因

Cloudflare D1 は HTTP API 経由で `BEGIN`/`COMMIT` を使うトランザクション（`db.transaction()`）をサポートしていないため、question_reply のログ保存が常に失敗していた。

## 修正

`db.transaction()` を削除し、`UPDATE ... WHERE answeredAt IS NULL AND userId = user.id RETURNING` に変更。SQLite の UPDATE 自体がアトミックなため重複防止の効果は同等。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **内部改善**
  * 質問への回答をマークする機能の内部処理を最適化しました。動作および機能に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->