### PR TITLE
fix: 0003 migration D1 FK 制約エラー修正

### DIFF
--- a/api/drizzle/0003_fixed_terror.sql
+++ b/api/drizzle/0003_fixed_terror.sql
@@ -1,15 +1,104 @@
-PRAGMA foreign_keys=OFF;--> statement-breakpoint
-CREATE TABLE `__new_users` (
-	`id` text PRIMARY KEY NOT NULL,
-	`discord_id` text,
-	`github_login` text NOT NULL,
-	`github_access_token` text,
-	`created_at` integer NOT NULL
+-- D1 では PRAGMA foreign_keys=OFF が別ステートメントに持続しないため
+-- 子テーブル(logs, questions)を先にバックアップして drop し、users を再作成する
+
+-- Step 1: データをバックアップ
+CREATE TABLE `__backup_users` (
+`id` text NOT NULL,
+`discord_id` text,
+`github_login` text NOT NULL,
+`github_access_token` text,
+`created_at` integer NOT NULL
 );
 --> statement-breakpoint
-INSERT INTO `__new_users`("id", "discord_id", "github_login", "github_access_token", "created_at") SELECT "id", "discord_id", "github_login", "github_access_token", "created_at" FROM `users`;--> statement-breakpoint
-DROP TABLE `users`;--> statement-breakpoint
-ALTER TABLE `__new_users` RENAME TO `users`;--> statement-breakpoint
-PRAGMA foreign_keys=ON;--> statement-breakpoint
-CREATE UNIQUE INDEX `users_discord_id_unique` ON `users` (`discord_id`);--> statement-breakpoint
+INSERT INTO `__backup_users` SELECT `id`, `discord_id`, `github_login`, `github_access_token`, `created_at` FROM `users`;
+--> statement-breakpoint
+CREATE TABLE `__backup_questions` (
+`id` text NOT NULL,
+`user_id` text NOT NULL,
+`github_repo` text NOT NULL,
+`commit_sha` text NOT NULL,
+`changed_files` text NOT NULL,
+`question_text` text NOT NULL,
+`discord_message_id` text,
+`answered_at` integer,
+`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__backup_questions` SELECT `id`, `user_id`, `github_repo`, `commit_sha`, `changed_files`, `question_text`, `discord_message_id`, `answered_at`, `created_at` FROM `questions`;
+--> statement-breakpoint
+CREATE TABLE `__backup_logs` (
+`id` text NOT NULL,
+`user_id` text NOT NULL,
+`question_id` text,
+`content` text NOT NULL,
+`source` text NOT NULL,
+`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__backup_logs` SELECT `id`, `user_id`, `question_id`, `content`, `source`, `created_at` FROM `logs`;
+--> statement-breakpoint
+
+-- Step 2: FK 制約を持つ子テーブルから順に drop
+DROP TABLE `logs`;
+--> statement-breakpoint
+DROP TABLE `questions`;
+--> statement-breakpoint
+DROP TABLE `users`;
+--> statement-breakpoint
+
+-- Step 3: users を discord_id nullable で再作成
+CREATE TABLE `users` (
+`id` text PRIMARY KEY NOT NULL,
+`discord_id` text,
+`github_login` text NOT NULL,
+`github_access_token` text,
+`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+
+-- Step 4: questions, logs を再作成
+CREATE TABLE `questions` (
+`id` text PRIMARY KEY NOT NULL,
+`user_id` text NOT NULL,
+`github_repo` text NOT NULL,
+`commit_sha` text NOT NULL,
+`changed_files` text NOT NULL,
+`question_text` text NOT NULL,
+`discord_message_id` text,
+`answered_at` integer,
+`created_at` integer NOT NULL,
+FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `logs` (
+`id` text PRIMARY KEY NOT NULL,
+`user_id` text NOT NULL,
+`question_id` text,
+`content` text NOT NULL,
+`source` text DEFAULT 'web' NOT NULL,
+`created_at` integer NOT NULL,
+FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action,
+FOREIGN KEY (`question_id`) REFERENCES `questions`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+
+-- Step 5: データを復元
+INSERT INTO `users` SELECT `id`, `discord_id`, `github_login`, `github_access_token`, `created_at` FROM `__backup_users`;
+--> statement-breakpoint
+INSERT INTO `questions` SELECT `id`, `user_id`, `github_repo`, `commit_sha`, `changed_files`, `question_text`, `discord_message_id`, `answered_at`, `created_at` FROM `__backup_questions`;
+--> statement-breakpoint
+INSERT INTO `logs` SELECT `id`, `user_id`, `question_id`, `content`, `source`, `created_at` FROM `__backup_logs`;
+--> statement-breakpoint
+
+-- Step 6: バックアップテーブルを削除
+DROP TABLE `__backup_logs`;
+--> statement-breakpoint
+DROP TABLE `__backup_questions`;
+--> statement-breakpoint
+DROP TABLE `__backup_users`;
+--> statement-breakpoint
+
+-- Step 7: インデックスを再作成
+CREATE UNIQUE INDEX `users_discord_id_unique` ON `users` (`discord_id`);
+--> statement-breakpoint
 CREATE UNIQUE INDEX `users_github_login_unique` ON `users` (`github_login`);


### PR DESCRIPTION
## 問題

`bun run migration:remote` で 0003 が失敗していた。

```
✘ [ERROR] FOREIGN KEY constraint failed: SQLITE_CONSTRAINT [code: 7500]
```

## 原因

D1 では `PRAGMA foreign_keys=OFF` が別ステートメントに持続しない。
そのため `DROP TABLE users` 実行時に `questions`/`logs` の FK 制約が有効なままで失敗。

## 修正

PRAGMA に頼らず、FK の順序を正しく制御する方式に変更：

1. `logs`, `questions`, `users` データをバックアップテーブルに退避
2. 子テーブルから順に DROP（logs → questions → users）
3. `users` を `discord_id` nullable で再作成
4. `questions`, `logs` を再作成
5. データを復元
6. バックアップテーブルを削除

## マージ後

```sh
cd api && bun run migration:remote
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ユーザーデータの管理構造を改善し、より堅牢なデータ整合性保護を実装しました。
  * データベース操作の信頼性を向上させるための処理フローを導入しました。
  * 既存データの安全性を維持しながらシステムの安定性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->