### PR TITLE
feat: エピソード取得API (POST /api/episodes) を実装 (#14)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { createDb } from "./db";
 import { authRoute } from "./routes/auth";
+import { episodesRoute } from "./routes/episodes";
 import { githubRoute } from "./routes/github";
 import { interactionsRoute } from "./routes/interactions";
 import { logsRoute } from "./routes/logs";
@@ -26,5 +27,6 @@ app.route("/api/webhooks", githubRoute);
 app.route("/api/webhooks", webhooksRoute);
 app.route("/api/interactions", interactionsRoute);
 app.route("/api/logs", logsRoute);
+app.route("/api/episodes", episodesRoute);
 
 export default app;

--- a/api/src/lib/gemini.ts
+++ b/api/src/lib/gemini.ts
@@ -19,6 +19,28 @@ ${JSON.stringify(files)}
 
 const FALLBACK_QUESTION = "今日のコードで一番詰まったところはどこでしたか？";
 
+const EPISODE_PROMPT = (logs: string[], userPrompt: string) =>
+  `
+あなたはエンジニアの成長を記録・整理するコーチです。
+以下のエンジニアのログ（学び・詰まったこと・解決したこと）をもとに、ユーザーのリクエストに答えてください。
+
+## ログ一覧
+${JSON.stringify(logs)}
+
+## ユーザーのリクエスト
+${userPrompt}
+
+## ルール
+- 日本語で回答する
+- ログの内容を具体的に引用・整理する
+- エンジニアの成長や学びを肯定的にまとめる
+- 箇条書きや見出しを活用して読みやすく整形する
+
+回答のみを出力してください（前置きや説明は不要）。
+`.trim();
+
+const FALLBACK_EPISODE = "ログの要約を生成できませんでした。しばらく後にもう一度お試しください。";
+
 export async function generateQuestion(
   apiKey: string,
   changedFiles: string[]
@@ -33,5 +55,23 @@ export async function generateQuestion(
   } catch (err) {
     console.error("Gemini API error:", err);
     return FALLBACK_QUESTION;
+  }
+}
+
+export async function generateEpisode(
+  apiKey: string,
+  logContents: string[],
+  userPrompt: string
+): Promise<string> {
+  const ai = new GoogleGenAI({ apiKey });
+  try {
+    const response = await ai.models.generateContent({
+      model: "gemini-2.5-flash",
+      contents: EPISODE_PROMPT(logContents, userPrompt)
+    });
+    return response.text ?? FALLBACK_EPISODE;
+  } catch (err) {
+    console.error("Gemini API error (episode):", err);
+    return FALLBACK_EPISODE;
   }
 }

--- a/api/src/routes/episodes.ts
+++ b/api/src/routes/episodes.ts
@@ -1,0 +1,61 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { episodeRequestSchema } from "@seedlog/schema";
+import { createDb } from "../db";
+import { logs, users } from "../db/schema";
+import { generateEpisode } from "../lib/gemini";
+
+const episodesRoute = new Hono<{ Bindings: CloudflareBindings }>();
+
+episodesRoute.post(
+  "/",
+  zValidator("json", episodeRequestSchema),
+  async (c) => {
+    const { userId, prompt } = c.req.valid("json");
+    const db = createDb(c.env.DB);
+
+    const user = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, userId))
+      .get();
+
+    if (!user) {
+      return c.json(
+        { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+        404
+      );
+    }
+
+    const userLogs = await db
+      .select({ content: logs.content, createdAt: logs.createdAt })
+      .from(logs)
+      .where(eq(logs.userId, userId))
+      .orderBy(logs.createdAt)
+      .all();
+
+    if (userLogs.length === 0) {
+      return c.json(
+        {
+          error: {
+            code: "NO_LOGS",
+            message: "ログがまだありません。ログを記録してからお試しください。"
+          }
+        },
+        422
+      );
+    }
+
+    const logContents = userLogs.map((l) => l.content);
+    const episode = await generateEpisode(
+      c.env.GEMINI_API_KEY,
+      logContents,
+      prompt
+    );
+
+    return c.json({ episode });
+  }
+);
+
+export { episodesRoute };

--- a/docs/api.md
+++ b/docs/api.md
@@ -383,7 +383,7 @@ offset?: number
 
 ## エピソード
 
-### `POST /api/episodes` 🔒
+### `POST /api/episodes` ✅ 実装済み 🔒
 
 過去のログをAIで整理・要約して返す。「LTネタまとめて」などのプロンプトに応答する。
 
@@ -396,12 +396,31 @@ offset?: number
 }
 ```
 
-**Response**
+**Response** `200 OK`
 
 ```typescript
 {
   episode: string; // AIが生成した要約テキスト
 }
 ```
+
+**処理の流れ**
+
+1. userId でユーザーを検索
+2. そのユーザーの全ログを取得（`createdAt` 昇順）
+3. ログ内容 + ユーザーのプロンプトを Gemini に渡して要約生成
+4. 生成結果を返す（Gemini エラー時はフォールバックメッセージを返す）
+
+**必要な環境変数**
+
+- `GEMINI_API_KEY`
+
+**Error Responses**
+
+- `404 Not Found` — ユーザーが見つからない
+- `422 Unprocessable Entity` — ログが0件
+  ```json
+  { "error": { "code": "NO_LOGS", "message": "ログがまだありません。ログを記録してからお試しください。" } }
+  ```
 
  

--- a/schema/src/index.ts
+++ b/schema/src/index.ts
@@ -136,3 +136,17 @@ export const logsListResponseSchema = z.object({
 });
 
 export type LogsListResponse = z.infer<typeof logsListResponseSchema>;
+
+// ---- Episodes ----
+
+export const episodeRequestSchema = z.object({
+  userId: z.string().min(1, "userIdは必須です"),
+  prompt: z.string().min(1, "promptは必須です")
+});
+
+export const episodeResponseSchema = z.object({
+  episode: z.string()
+});
+
+export type EpisodeRequest = z.infer<typeof episodeRequestSchema>;
+export type EpisodeResponse = z.infer<typeof episodeResponseSchema>;


### PR DESCRIPTION
## 概要

issue #14 エピソード取得API（AI要約機能）の実装。

## 変更内容

- `POST /api/episodes` エンドポイントを追加
- ユーザーの全ログを取得し、Gemini APIでプロンプトに応じた要約を生成して返す
- Gemini障害時はフォールバックメッセージを返す（エラーは投げない）
- ログが0件の場合は422を返す

## ファイル

- `api/src/routes/episodes.ts` — 新規作成
- `api/src/lib/gemini.ts` — `generateEpisode` 関数を追加
- `schema/src/index.ts` — `episodeRequestSchema` / `episodeResponseSchema` を追加
- `api/src/index.ts` — `/api/episodes` ルートを登録
- `docs/api.md` — 実装済みに更新、エラーレスポンス追記

## 動作確認

型チェック通過済み。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * エピソード生成機能を新たに追加しました。ユーザーのログからプロンプトに基づいてエピソードを自動生成できるようになります。

* **Documentation**
  * API ドキュメントを更新しました。エピソード生成エンドポイント、ユーザー作成時の Discord ID オプション化、および関連するエラーハンドリングについて説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->