### PR TITLE
feat: GET /api/repos — リポジトリ一覧取得API

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -6,6 +6,7 @@ import { episodesRoute } from "./routes/episodes";
 import { githubRoute } from "./routes/github";
 import { interactionsRoute } from "./routes/interactions";
 import { logsRoute } from "./routes/logs";
+import { reposRoute } from "./routes/repos";
 import { usersRoute } from "./routes/users";
 import { webhooksRoute } from "./routes/webhooks";
 
@@ -28,5 +29,6 @@ app.route("/api/webhooks", webhooksRoute);
 app.route("/api/interactions", interactionsRoute);
 app.route("/api/logs", logsRoute);
 app.route("/api/episodes", episodesRoute);
+app.route("/api/repos", reposRoute);
 
 export default app;

--- a/api/src/routes/repos.ts
+++ b/api/src/routes/repos.ts
@@ -1,0 +1,96 @@
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { getSignedCookie } from "hono/cookie";
+import { createDb } from "../db";
+import { users } from "../db/schema";
+import { decryptToken } from "../lib/token-crypto";
+
+const reposRoute = new Hono<{ Bindings: CloudflareBindings }>();
+
+reposRoute.get("/", async (c) => {
+  const githubLogin = await getSignedCookie(
+    c,
+    c.env.COOKIE_SECRET,
+    "github_user"
+  );
+  if (!githubLogin) {
+    return c.json(
+      { error: { code: "UNAUTHORIZED", message: "GitHub認証が必要です" } },
+      401
+    );
+  }
+
+  const db = createDb(c.env.DB);
+  const user = await db
+    .select()
+    .from(users)
+    .where(eq(users.githubLogin, githubLogin))
+    .get();
+
+  if (!user) {
+    return c.json(
+      { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+      404
+    );
+  }
+  if (!user.githubAccessToken) {
+    return c.json(
+      {
+        error: {
+          code: "UNAUTHORIZED",
+          message: "GitHub連携が完了していません"
+        }
+      },
+      401
+    );
+  }
+
+  const accessToken = await decryptToken(
+    user.githubAccessToken,
+    c.env.GITHUB_TOKEN_ENCRYPTION_KEY
+  );
+
+  const res = await fetch(
+    "https://api.github.com/user/repos?type=owner&sort=updated&per_page=100",
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "User-Agent": "seedlog-api",
+        Accept: "application/vnd.github+json"
+      }
+    }
+  );
+
+  if (!res.ok) {
+    console.error("GitHub repos fetch error:", await res.text());
+    return c.json(
+      {
+        error: {
+          code: "GITHUB_API_ERROR",
+          message: "リポジトリ一覧の取得に失敗しました"
+        }
+      },
+      502
+    );
+  }
+
+  const rawRepos = (await res.json()) as {
+    name: string;
+    full_name: string;
+    private: boolean;
+    description: string | null;
+    updated_at: string;
+  }[];
+
+  const repos = rawRepos.map((r) => ({
+    name: r.name,
+    fullName: r.full_name,
+    private: r.private,
+    description: r.description,
+    updatedAt: r.updated_at
+  }));
+
+  return c.json({ repos });
+});
+
+export { reposRoute };

--- a/docs/api.md
+++ b/docs/api.md
@@ -158,6 +158,42 @@ error?: string
 
 ---
 
+### `GET /api/repos` ✅ 実装済み
+
+ログイン済みユーザーの GitHub リポジトリ一覧を取得する。フロントエンドでリポジトリを選択し、`POST /api/webhooks/register` に渡すために使用する。
+
+**認証**
+
+`github_user` 署名済み Cookie（GitHub OAuth ログイン後に自動セット）
+
+**Response** `200 OK`
+
+```typescript
+{
+  repos: {
+    name: string;           // リポジトリ名
+    fullName: string;       // "owner/repo" 形式
+    private: boolean;
+    description: string | null;
+    updatedAt: string;      // ISO 8601
+  }[];
+}
+```
+
+**取得条件**
+
+- type=owner（自分がオーナーのリポジトリのみ）
+- sort=updated（最終更新順）
+- per_page=100（最大100件）
+
+**Error Responses**
+
+- `401 Unauthorized` — 未ログイン、または GitHub 未連携
+- `404 Not Found` — ユーザーが見つからない
+- `502 Bad Gateway` — GitHub API エラー
+
+---
+
 ### `POST /api/webhooks/register` ✅ 実装済み
 
 指定リポジトリに GitHub Webhook を自動登録する。

--- a/schema/src/index.ts
+++ b/schema/src/index.ts
@@ -150,3 +150,20 @@ export const episodeResponseSchema = z.object({
 
 export type EpisodeRequest = z.infer<typeof episodeRequestSchema>;
 export type EpisodeResponse = z.infer<typeof episodeResponseSchema>;
+
+// ---- Repos ----
+
+export const repoSchema = z.object({
+  name: z.string(),
+  fullName: z.string(),
+  private: z.boolean(),
+  description: z.string().nullable(),
+  updatedAt: z.string()
+});
+
+export const reposResponseSchema = z.object({
+  repos: z.array(repoSchema)
+});
+
+export type Repo = z.infer<typeof repoSchema>;
+export type ReposResponse = z.infer<typeof reposResponseSchema>;


### PR DESCRIPTION
## 概要

ログイン済みユーザーの GitHub リポジトリ一覧を返す `GET /api/repos` を追加。

フロント側でリポジトリ選択UIを実装できるようになる。

## フロー

1. ユーザーが GitHub OAuth でログイン（変更なし）
2. フロントが `GET /api/repos` を呼んでリポジトリ一覧を表示
3. ユーザーが対象リポジトリを選択
4. `POST /api/webhooks/register` で選択リポジトリに Webhook 登録

## 変更内容

- `api/src/routes/repos.ts` — 新規作成
- `schema/src/index.ts` — `repoSchema` / `reposResponseSchema` を追加
- `api/src/index.ts` — `/api/repos` 登録
- `docs/api.md` — エンドポイントを追記

## 型チェック

通過済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 認証済みユーザーがGitHubリポジトリ一覧を取得できる新しいAPIエンドポイントを追加。リポジトリ名、所有者情報、公開状態、説明、更新日時が取得可能になりました。

* **ドキュメント**
  * APIドキュメントを更新し、新しいリポジトリ取得エンドポイントの仕様、認証要件、エラーハンドリングについて記載しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->