### PR TITLE
refactor: DiscordCallbackPage を useEffect から useSWR に変更

### DIFF
--- a/web/src/pages/DiscordCallbackPage.tsx
+++ b/web/src/pages/DiscordCallbackPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import useSWR from "swr";
 import type { DiscordTokenResponse } from "@seedlog/schema";
 import { apiFetch } from "../lib/api";
@@ -19,22 +20,21 @@ export default function DiscordCallbackPage() {
     ([, c]) => exchangeCode(c)
   );
 
-  if (!code) {
-    window.location.replace("/auth/error?reason=oauth_error");
-    return null;
-  }
-
-  if (error) {
-    window.location.replace("/auth/error?reason=discord_link_failed");
-    return null;
-  }
-
-  if (data) {
-    localStorage.setItem("discordId", data.discordId);
-    localStorage.setItem("discordUsername", data.discordUsername);
-    window.location.replace("/repos");
-    return null;
-  }
+  useEffect(() => {
+    if (!code) {
+      window.location.replace("/auth/error?reason=oauth_error");
+      return;
+    }
+    if (error) {
+      window.location.replace("/auth/error?reason=discord_link_failed");
+      return;
+    }
+    if (data) {
+      localStorage.setItem("discordId", data.discordId);
+      localStorage.setItem("discordUsername", data.discordUsername);
+      window.location.replace("/repos");
+    }
+  }, [code, error, data]);
 
   return (
     <div className="min-h-screen bg-gray-950 flex items-center justify-center">


### PR DESCRIPTION
## 概要

`DiscordCallbackPage.tsx` の実装を `useEffect` + `fetch` から `useSWR` に変更。

## 変更内容

- `useEffect` を削除し `useSWR` で code → Discord ユーザー情報の交換を管理
- `lib/api.ts` の `apiFetch` を使用して fetch 呼び出しを統一
- `code` が null の場合はフェッチをスキップ（`useSWR` の key に `null` を渡す）
- `data` 取得時に localStorage 保存 → `/repos` リダイレクト
- `error` 時は `/auth/error` へリダイレクト

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord認証フローのエラーハンドリングを改善しました。Discord連携失敗時や認証コード不在時に、ユーザーはより詳細なエラーページにリダイレクトされるようになります。

* **Refactor**
  * Discord認証プロセスのデータ取得メカニズムを最適化し、より信頼性の高い非同期フロー処理を実装しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->