### PR TITLE
feat: GitHub Webhook 解除機能を追加し、APIドキュメントを更新

### DIFF
--- a/api/src/routes/webhooks.ts
+++ b/api/src/routes/webhooks.ts
@@ -3,7 +3,9 @@ import { Hono } from "hono";
 import { getSignedCookie } from "hono/cookie";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import {
+  webhookMutationResponseSchema,
   registerWebhookSchema,
+  unregisterWebhookSchema,
   webhooksListResponseSchema
 } from "@seedlog/schema";
 import { createDb } from "../db";
@@ -31,6 +33,16 @@ async function addWebhookRecord(
     records.push({ repo, hookId });
     await kv.put(`webhooks:${userId}`, JSON.stringify(records));
   }
+}
+
+async function removeWebhookRecord(
+  kv: KVNamespace,
+  userId: string,
+  repo: string
+): Promise<void> {
+  const records = await getWebhookRecords(kv, userId);
+  const nextRecords = records.filter((record) => record.repo !== repo);
+  await kv.put(`webhooks:${userId}`, JSON.stringify(nextRecords));
 }
 
 const webhooksRoute = new Hono<{ Bindings: CloudflareBindings }>();
@@ -241,6 +253,118 @@ webhooksRoute.post(
     const hook = (await res.json()) as { id: number };
     await addWebhookRecord(c.env.WEBHOOK_KV, user.id, repo, hook.id);
     return c.json({ ok: true, hookId: hook.id }, 201);
+  }
+);
+
+webhooksRoute.delete(
+  "/unregister",
+  describeRoute({
+    description:
+      "GitHub リポジトリの Webhook を解除する（要: github_user Cookie）",
+    tags: ["Webhooks"],
+    responses: {
+      200: {
+        description: "Webhook 解除成功",
+        content: {
+          "application/json": {
+            schema: resolver(webhookMutationResponseSchema)
+          }
+        }
+      },
+      401: { description: "GitHub認証が必要です" },
+      404: { description: "ユーザーまたは Webhook が見つかりません" },
+      502: { description: "GitHub API エラー" }
+    }
+  }),
+  validator("json", unregisterWebhookSchema),
+  async (c) => {
+    const githubLogin = await getSignedCookie(
+      c,
+      c.env.COOKIE_SECRET,
+      "github_user"
+    );
+    if (!githubLogin) {
+      return c.json(
+        { error: { code: "UNAUTHORIZED", message: "GitHub認証が必要です" } },
+        401
+      );
+    }
+
+    const { repo } = c.req.valid("json");
+    const db = createDb(c.env.DB);
+    const user = await db
+      .select()
+      .from(users)
+      .where(eq(users.githubLogin, githubLogin))
+      .get();
+
+    if (!user) {
+      return c.json(
+        { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+        404
+      );
+    }
+    if (!user.githubAccessToken) {
+      return c.json(
+        {
+          error: {
+            code: "UNAUTHORIZED",
+            message: "GitHub連携が完了していません"
+          }
+        },
+        401
+      );
+    }
+
+    const records = await getWebhookRecords(c.env.WEBHOOK_KV, user.id);
+    const record = records.find((item) => item.repo === repo);
+    if (!record) {
+      return c.json(
+        {
+          error: {
+            code: "NOT_FOUND",
+            message: "Webhook が登録されていません"
+          }
+        },
+        404
+      );
+    }
+
+    if (record.hookId !== null) {
+      const accessToken = await decryptToken(
+        user.githubAccessToken,
+        c.env.GITHUB_TOKEN_ENCRYPTION_KEY
+      );
+      const [owner, repoName] = repo.split("/");
+      const res = await fetch(
+        `https://api.github.com/repos/${owner}/${repoName}/hooks/${record.hookId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: "application/vnd.github+json",
+            "User-Agent": "seedlog-api"
+          }
+        }
+      );
+
+      if (!res.ok && res.status !== 404) {
+        const text = await res.text();
+        console.error("GitHub webhook 解除エラー:", text);
+        return c.json(
+          {
+            error: {
+              code: "GITHUB_API_ERROR",
+              message: "webhook解除に失敗しました"
+            }
+          },
+          502
+        );
+      }
+    }
+
+    await removeWebhookRecord(c.env.WEBHOOK_KV, user.id, repo);
+    return c.json({ ok: true });
   }
 );
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -325,6 +325,41 @@ error?: string
 
 ---
 
+### `DELETE /api/webhooks/unregister` ✅ 実装済み
+
+指定リポジトリの GitHub Webhook 登録を解除する。
+
+**Request**
+
+```typescript
+{
+  repo: string; // "owner/repo" 形式（認証ユーザーは github_user 署名済み Cookie から解決）
+}
+```
+
+**処理の流れ**
+
+1. `github_user` cookie から認証済みユーザーの GitHub login を解決
+2. KV に保存された対象 repo の webhook record を取得
+3. `hookId` がある場合のみ GitHub API `DELETE /repos/{owner}/{repo}/hooks/{hookId}` を呼び出し
+4. GitHub 側が 404 または `hookId` が null の場合も、KV 上の登録記録は削除する
+
+**Response** `200 OK`
+
+```typescript
+{
+  ok: true;
+}
+```
+
+**Error Responses**
+
+- `401 Unauthorized` — `github_user` cookie が未設定、または GitHub 未連携（githubAccessToken が未設定）
+- `404 Not Found` — ユーザーまたは対象 webhook record が見つからない
+- `502 Bad Gateway` — GitHub API エラー
+
+---
+
 ## Discord Interactions
 
 ### `POST /api/interactions` ✅ 実装済み

--- a/schema/src/index.ts
+++ b/schema/src/index.ts
@@ -110,7 +110,24 @@ export const registerWebhookSchema = z.object({
     .regex(/^[^/]+\/[^/]+$/, "repo は owner/repo 形式で指定してください")
 });
 
+export const unregisterWebhookSchema = z.object({
+  repo: z
+    .string()
+    .min(1, "repoは必須です")
+    .regex(/^[^/]+\/[^/]+$/, "repo は owner/repo 形式で指定してください")
+});
+
+export const webhookMutationResponseSchema = z.object({
+  ok: z.boolean(),
+  message: z.string().optional(),
+  hookId: z.number().nullable().optional()
+});
+
 export type RegisterWebhookInput = z.infer<typeof registerWebhookSchema>;
+export type UnregisterWebhookInput = z.infer<typeof unregisterWebhookSchema>;
+export type WebhookMutationResponse = z.infer<
+  typeof webhookMutationResponseSchema
+>;
 
 // ---- Logs ----
 

--- a/web/src/pages/ReposPage.tsx
+++ b/web/src/pages/ReposPage.tsx
@@ -8,7 +8,13 @@ import type {
 import { apiFetch, API_BASE, fetcher } from "../lib/api";
 import { Lock } from "lucide-react";
 
-type WebhookStatus = "idle" | "loading" | "done" | "exists" | "error";
+type WebhookStatus =
+  | "idle"
+  | "loading"
+  | "unregistering"
+  | "done"
+  | "exists"
+  | "error";
 
 function RepoItem({
   repo,
@@ -47,6 +53,35 @@ function RepoItem({
     }
   }
 
+  async function unregisterWebhook() {
+    const shouldUnregister = window.confirm(
+      `${repo.fullName} の Webhook 登録を解除しますか？`
+    );
+    if (!shouldUnregister) return;
+
+    setStatus("unregistering");
+    try {
+      const res = await apiFetch("/api/webhooks/unregister", {
+        method: "DELETE",
+        body: JSON.stringify({ repo: repo.fullName })
+      });
+      const data = (await res.json()) as {
+        ok?: boolean;
+        error?: { code: string; message: string };
+      };
+      if (!res.ok) {
+        console.error(data.error);
+        setStatus("error");
+        return;
+      }
+      setStatus("idle");
+      await mutate("/api/webhooks");
+    } catch (err) {
+      console.error("Webhook 解除に失敗しました:", err);
+      setStatus("error");
+    }
+  }
+
   return (
     <div className="flex items-center justify-between p-4 rounded-lg">
       <div className="min-w-0">
@@ -79,19 +114,41 @@ function RepoItem({
         {status === "loading" && (
           <span className="text-sm text-muted-foreground">登録中...</span>
         )}
-        {status === "done" && (
-          <span className="text-sm text-green-400">✅ 登録済み</span>
+        {status === "unregistering" && (
+          <span className="text-sm text-muted-foreground">解除中...</span>
         )}
-        {status === "exists" && (
-          <span className="text-sm text-yellow-400">⚠️ 既に登録済み</span>
+        {(status === "done" || status === "exists") && (
+          <div className="flex items-center gap-3">
+            <span
+              className={`text-sm ${status === "exists" ? "text-yellow-400" : "text-green-400"}`}
+            >
+              {status === "exists" ? "⚠️ 既に登録済み" : "✅ 登録済み"}
+            </span>
+            <button
+              onClick={unregisterWebhook}
+              className="text-sm bg-neutral-800 text-neutral-200 px-3 py-1.5 rounded hover:bg-neutral-700 transition-colors"
+            >
+              解除
+            </button>
+          </div>
         )}
         {status === "error" && (
-          <button
-            onClick={registerWebhook}
-            className="text-sm bg-red-600 text-white px-3 py-1.5 rounded hover:bg-red-500 transition-colors"
-          >
-            失敗（再試行）
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={registerWebhook}
+              className="text-sm bg-red-600 text-white px-3 py-1.5 rounded hover:bg-red-500 transition-colors"
+            >
+              登録を再試行
+            </button>
+            {isRegistered && (
+              <button
+                onClick={unregisterWebhook}
+                className="text-sm bg-neutral-800 text-neutral-200 px-3 py-1.5 rounded hover:bg-neutral-700 transition-colors"
+              >
+                解除
+              </button>
+            )}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHubリポジトリのWebhook登録を解除できるようになりました
  * リポジトリ一覧ページに「解除」ボタンを追加し、ワンクリックで登録済みのWebhookを削除できます

* **ドキュメント**
  * 新しいWebhook解除APIエンドポイントのドキュメントを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->