### PR TITLE
feat: ダッシュボードヘッダーのリファクタリングとDiscord連携機能の追加

### DIFF
--- a/web/src/components/dashboard-header.tsx
+++ b/web/src/components/dashboard-header.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { API_BASE } from "../lib/api";
 
 // 通知データの型定義
-export default function ReposPage() {
+export default function DashboardHeader() {
   const [githubLogin, setGithubLogin] = useState<string | null>(null);
   const [discordUsername, setDiscordUsername] = useState<string | null>(null);
   const [_discordBotInstallFlag, setDiscordBotInstallFlag] = useState<
@@ -23,8 +23,8 @@ export default function ReposPage() {
   }, []);
 
   return (
-    <div className="min-h-screen">
-    <header className="border-b border-neutral-800 px-6 py-4 flex items-center justify-between">
+      <>
+          <header className="border-b border-neutral-800 px-6 py-4 flex items-center justify-between">
             <h1 className="text-xl font-bold">🌱 Seedlog</h1>
             <div className="flex items-center gap-4">
               {githubLogin && (
@@ -65,17 +65,17 @@ export default function ReposPage() {
               )}
             </div>
           </header>
-      {discordUsername && discordDmDeliverable === "0" && (
-        <div className="max-w-2xl mx-auto px-6 pt-4">
-          <p className="text-sm text-red-300">
-            DMを送信できませんでした（
-            {discordDmReason === "blocked_or_closed"
-              ? "DM受信設定またはBotブロック"
-              : "不明なエラー"}
-            ）。Discord 再連携で再チェックできます。
-          </p>
-        </div>
-      )}
-    </div>
+        {discordUsername && discordDmDeliverable === "0" && (
+          <div className="max-w-2xl mx-auto px-6 pt-4">
+            <p className="text-sm text-red-300">
+              DMを送信できませんでした（
+              {discordDmReason === "blocked_or_closed"
+                ? "DM受信設定またはBotブロック"
+                : "不明なエラー"}
+              ）。Discord 再連携で再チェックできます。
+            </p>
+          </div>
+        )}
+      </>
   )
 }


### PR DESCRIPTION
- 不要なインポートを削除し、API_BASEを追加
- GitHubログインとDiscordユーザー名を表示する機能を追加
- DM受信可能かどうかのステータスを表示
- Discord再連携とBot追加のリンクを追加
- DM送信失敗時のエラーメッセージを改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ヘッダーにDiscord接続ステータスインジケーターを追加しました。
  * Discord関連のリンク（接続設定、ボットインストール）を新たに表示するようになりました。

* **改善**
  * ダッシュボードヘッダーのレイアウトを簡潔に再設計しました。
  * ユーザー識別情報（GitHubログイン、Discordユーザー名）をヘッダーに表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->