### PR TITLE
Add web repo selector for log creation (repo nullable)

### DIFF
--- a/api/src/routes/logs.ts
+++ b/api/src/routes/logs.ts
@@ -1,7 +1,9 @@
 import { and, count, eq } from "drizzle-orm";
 import { Hono } from "hono";
+import { nanoid } from "nanoid";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import {
+  createLogRequestSchema,
   logResponseSchema,
   logsListResponseSchema,
   logsQuerySchema
@@ -77,6 +79,66 @@ logsRoute.get(
       total,
       hasMore: offset + rows.length < total
     });
+  }
+);
+
+logsRoute.post(
+  "/",
+  describeRoute({
+    description: "ログを手動で追加する",
+    tags: ["Logs"],
+    responses: {
+      201: {
+        description: "作成されたログ",
+        content: {
+          "application/json": { schema: resolver(logResponseSchema) }
+        }
+      },
+      401: { description: "未認証" }
+    }
+  }),
+  validator("json", createLogRequestSchema),
+  async (c) => {
+    const currentUser = await resolveCurrentUser(c);
+
+    if (!currentUser.user) {
+      c.header("Cache-Control", "private, no-store");
+      c.header("Vary", "Cookie");
+      return c.json(
+        { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+        401
+      );
+    }
+
+    const { content, source, repo } = c.req.valid("json");
+    const db = createDb(c.env.DB);
+    const id = nanoid();
+    const createdAt = new Date();
+
+    await db.insert(logs).values({
+      id,
+      userId: currentUser.user.id,
+      questionId: null,
+      repo,
+      content,
+      source,
+      createdAt
+    });
+
+    c.header("Cache-Control", "private, no-store");
+    c.header("Vary", "Cookie");
+    return c.json(
+      logResponseSchema.parse({
+        id,
+        userId: currentUser.user.id,
+        questionId: null,
+        repo,
+        content,
+        source,
+        createdAt: createdAt.toISOString()
+      }),
+      201
+    );
   }
 );
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -460,7 +460,7 @@ offset?: number
 }
 ```
 
-### `POST /api/logs` 🔒
+### `POST /api/logs` ✅ 実装済み 🔒
 
 手動でログを追加（WebアプリとDiscordコマンド共通）。
 
@@ -468,11 +468,30 @@ offset?: number
 
 ```typescript
 {
-  userId: string;
   content: string;
-  source: "discord_command" | "web";
+  source?: "discord_command" | "web"; // 省略時は "web"
+  repo?: string | null; // "owner/repo" 形式 or null
 }
 ```
+
+**Response** `201 Created`
+
+```typescript
+{
+  id: string;
+  userId: string;
+  questionId: null;
+  repo: string | null;
+  content: string;
+  source: "discord_command" | "web";
+  createdAt: string; // ISO 8601
+}
+```
+
+**Error Responses**
+
+- `401 Unauthorized` — 未認証
+- `400 Bad Request` — 入力バリデーションエラー（例: repo が owner/repo 形式ではない）
 
 ### `GET /api/logs/:id` 🔒
 

--- a/schema/src/index.ts
+++ b/schema/src/index.ts
@@ -152,6 +152,24 @@ export const logSourceSchema = z.enum([
   "web"
 ]);
 
+export const createLogSourceSchema = z.enum(["discord_command", "web"]);
+
+export const createLogRequestSchema = z.object({
+  content: z
+    .string()
+    .trim()
+    .min(1, "contentは必須です")
+    .max(2000, "contentは2000文字以内で入力してください"),
+  source: createLogSourceSchema.default("web"),
+  repo: z
+    .string()
+    .trim()
+    .regex(/^[^/]+\/[^/]+$/, "repo は owner/repo 形式で指定してください")
+    .nullable()
+    .optional()
+    .transform((value) => value ?? null)
+});
+
 export const logResponseSchema = z.object({
   id: z.string(),
   userId: z.string(),
@@ -170,6 +188,7 @@ export const logsQuerySchema = z.object({
 
 export type LogResponse = z.infer<typeof logResponseSchema>;
 export type LogsQuery = z.infer<typeof logsQuerySchema>;
+export type CreateLogRequest = z.infer<typeof createLogRequestSchema>;
 
 export const logsListResponseSchema = z.object({
   logs: z.array(logResponseSchema),

--- a/web/src/components/log-form.tsx
+++ b/web/src/components/log-form.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import useSWR from "swr";
+import type { Repo, ReposResponse } from "@seedlog/schema";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Plus, X } from "lucide-react";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, fetcher } from "@/lib/api";
 
 interface LogFormProps {
   onLogCreated?: () => void;
@@ -15,8 +17,14 @@ interface LogFormProps {
 export function LogForm({ onLogCreated, prefillContent }: LogFormProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [content, setContent] = useState("");
+  const [repo, setRepo] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, setIsPending] = useState(false);
+  const { data: reposData } = useSWR<ReposResponse>(
+    isOpen ? "/api/repos?per_page=100" : null,
+    fetcher
+  );
+  const repos: Repo[] = reposData?.repos ?? [];
 
   useEffect(() => {
     if (prefillContent) {
@@ -36,7 +44,8 @@ export function LogForm({ onLogCreated, prefillContent }: LogFormProps) {
         method: "POST",
         body: JSON.stringify({
           content,
-          source: "web"
+          source: "web",
+          repo: repo === "" ? null : repo
         })
       });
 
@@ -47,6 +56,7 @@ export function LogForm({ onLogCreated, prefillContent }: LogFormProps) {
 
       setIsOpen(false);
       setContent("");
+      setRepo("");
       onLogCreated?.();
     } catch (err: any) {
       setError(err.message);
@@ -85,6 +95,30 @@ export function LogForm({ onLogCreated, prefillContent }: LogFormProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="repo" className="text-sm font-medium">
+              リポジトリ（任意）
+            </label>
+            <select
+              id="repo"
+              name="repo"
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden"
+            >
+              <option value="">リポジトリなし</option>
+              {repos.map((item) => (
+                <option key={item.fullName} value={item.fullName}>
+                  {item.fullName}
+                </option>
+              ))}
+            </select>
+            {reposData?.incomplete && (
+              <p className="text-muted-foreground text-xs">
+                候補は一部のみ表示されています（検索条件で絞り込んでください）
+              </p>
+            )}
+          </div>
           <Textarea
             name="content"
             placeholder="今日学んだこと、詰まったエラー、解決策などを自由に書いてください。"


### PR DESCRIPTION
## Summary
- add create-log request schema with optional nullable repo
- implement authenticated POST /api/logs for manual log creation
- add repo selector in web LogForm with 'リポジトリなし' option
- update API docs for POST /api/logs request/response

## Validation
- bun run check
- bun run type-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* ログ作成 API エンドポイント（POST /api/logs）を実装しました
* ログフォームにリポジトリ選択機能を追加しました（動的データ取得対応）

## ドキュメント
* API ドキュメントを更新し、新しいエンドポイントのリクエスト・レスポンススキーマとエラーレスポンス仕様を記載しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->