### PR TITLE
fix(api): organisationのadmin repoが表示されない問題を修正

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -406,7 +406,7 @@ authRoute.get("/github", (c) => {
   const params = new URLSearchParams({
     client_id: c.env.GITHUB_CLIENT_ID,
     redirect_uri: c.env.GITHUB_REDIRECT_URI,
-    scope: "admin:repo_hook read:user",
+    scope: "repo read:org admin:repo_hook read:user",
     state
   });
   return c.redirect(`${GITHUB_OAUTH_URL}?${params}`);

--- a/api/src/routes/repos.ts
+++ b/api/src/routes/repos.ts
@@ -17,6 +17,12 @@ type GitHubRepo = {
   private: boolean;
   description: string | null;
   updated_at: string;
+  owner: {
+    type: string;
+  };
+  permissions?: {
+    admin: boolean;
+  };
 };
 
 type RepoListItem = ReposResponse["repos"][number];
@@ -47,6 +53,19 @@ function isGitHubRepo(value: unknown): value is GitHubRepo {
     return false;
   }
 
+  const owner = value.owner;
+  if (!isRecord(owner) || typeof owner.type !== "string") {
+    return false;
+  }
+
+  const permissions = value.permissions;
+  if (
+    permissions !== undefined &&
+    (!isRecord(permissions) || typeof permissions.admin !== "boolean")
+  ) {
+    return false;
+  }
+
   return (
     typeof value.name === "string" &&
     typeof value.full_name === "string" &&
@@ -58,6 +77,17 @@ function isGitHubRepo(value: unknown): value is GitHubRepo {
 
 function isGitHubRepoArray(value: unknown): value is GitHubRepo[] {
   return Array.isArray(value) && value.every((repo) => isGitHubRepo(repo));
+}
+
+function isOrganizationRepo(repo: GitHubRepo): boolean {
+  return repo.owner.type.toLowerCase() === "organization";
+}
+
+function shouldIncludeRepo(repo: GitHubRepo): boolean {
+  if (!isOrganizationRepo(repo)) {
+    return true;
+  }
+  return repo.permissions?.admin === true;
 }
 
 async function fetchGitHubReposPage(params: {
@@ -103,13 +133,15 @@ async function fetchGitHubReposPage(params: {
     };
   }
 
-  const repos = payload.map((repo) => ({
-    name: repo.name,
-    fullName: repo.full_name,
-    private: repo.private,
-    description: repo.description,
-    updatedAt: repo.updated_at
-  }));
+  const repos = payload
+    .filter((repo) => shouldIncludeRepo(repo))
+    .map((repo) => ({
+      name: repo.name,
+      fullName: repo.full_name,
+      private: repo.private,
+      description: repo.description,
+      updatedAt: repo.updated_at
+    }));
   const link = res.headers.get("Link") ?? "";
   const hasNextPage = link.includes('rel="next"');
 
@@ -233,25 +265,7 @@ reposRoute.get(
 
     const { page, per_page, query } = c.req.valid("query");
 
-    if (!query) {
-      const result = await fetchGitHubReposPage({
-        accessToken,
-        page,
-        perPage: per_page
-      });
-      if (!result.ok) {
-        return githubReposErrorResponse(c, result.status, result.error);
-      }
-
-      c.header("Cache-Control", "private, no-store");
-      c.header("Vary", "Cookie");
-      return c.json({
-        repos: result.repos,
-        hasNextPage: result.hasNextPage
-      } satisfies ReposResponse);
-    }
-
-    const keyword = query.toLowerCase();
+    const keyword = query?.toLowerCase();
     const startIndex = (page - 1) * per_page;
     const endExclusive = startIndex + per_page;
     let matchedCount = 0;
@@ -282,7 +296,7 @@ reposRoute.get(
             .toLowerCase()
             .trim();
 
-        if (!searchable.includes(keyword)) {
+        if (keyword && !searchable.includes(keyword)) {
           continue;
         }
 
@@ -303,9 +317,10 @@ reposRoute.get(
     const truncatedByGitHubCap =
       hasGitHubNextPage && scannedItems >= GITHUB_REPOS_SCAN_MAX_ITEMS;
     const incomplete = truncatedByScanLimit || truncatedByGitHubCap;
-    const message = incomplete
-      ? `検索対象が上限(${GITHUB_REPOS_SCAN_MAX_ITEMS}件)に達したため、結果が一部のみ表示されています`
-      : undefined;
+    const message =
+      query && incomplete
+        ? `検索対象が上限(${GITHUB_REPOS_SCAN_MAX_ITEMS}件)に達したため、結果が一部のみ表示されています`
+        : undefined;
 
     c.header("Cache-Control", "private, no-store");
     c.header("Vary", "Cookie");

--- a/docs/api.md
+++ b/docs/api.md
@@ -175,7 +175,7 @@ GitHub OAuth 認証フローを開始する。
 **処理の流れ**
 
 1. CSRF 対策用のランダム state を生成し `github_oauth_state` cookie にセット（httpOnly, Secure, SameSite=Lax, 5分）
-2. GitHub の OAuth 認可画面へリダイレクト（scope: `admin:repo_hook read:user`）
+2. GitHub の OAuth 認可画面へリダイレクト（scope: `repo read:org admin:repo_hook read:user`）
 
 **必要な環境変数**
 
@@ -284,6 +284,7 @@ error?: string
 **取得条件**
 
 - affiliation=owner,collaborator,organization_member（オーナー・コラボレータ・組織所属リポジトリ）
+- organisation リポジトリは `permissions.admin=true`（認証ユーザーが admin 権限を持つもの）のみを返却
 - sort=updated（最終更新順）
 - `query` 指定時は `name` / `fullName` / `description` を対象にサーバー側で部分一致検索し、検索結果に対して `page` / `per_page` を適用
 - `query` 指定時の走査は最大 5000 件（100件 × 50ページ）。上限に達しても続きがある場合、`incomplete: true` が返る


### PR DESCRIPTION
## 概要
- GitHub OAuth scope を repo read:org admin:repo_hook read:user に拡張
- /api/repos で organisation repo は permissions.admin=true のみ返却
- APIドキュメントを実装に合わせて更新

## 動作確認
- bun run check
- bun run type-check

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * GitHub リポジトリの検索とフィルタリング機能を改善しました。

* **改善**
  * 組織リポジトリへのアクセス制御を強化しました。管理者権限のあるユーザーのみがアクセスできるようになりました。

* **ドキュメント**
  * API ドキュメントを更新しました。OAuth 認可スコープとリポジトリアクセス制御に関する説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->